### PR TITLE
Fix typo in api database error message

### DIFF
--- a/report/api.php
+++ b/report/api.php
@@ -97,7 +97,7 @@ if ($request_method === 'POST') {
         $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     } catch (PDOException $e) {
         http_response_code(500);
-	log_message("ERROR", "Database connectino failed", $client, $hostname, $client_ip, $conn);
+        log_message("ERROR", "Database connection failed", $client, $hostname, $client_ip, $conn);
         exit;
     }
 


### PR DESCRIPTION
## Summary
- fix typo in database connection error handling

## Testing
- `php -l report/api.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68673d08e4548321896d8d78924024e9