### PR TITLE
Fix API key lookup

### DIFF
--- a/report/api.php
+++ b/report/api.php
@@ -114,14 +114,15 @@ if ($request_method === 'POST') {
     $chkAPI_stmt->bindParam(':api_key', $api_key);
     $chkAPI_stmt->execute();
     $result = $chkAPI_stmt->fetch(PDO::FETCH_ASSOC);
-    $server_name = $result['server_name'];
-    $client = $result['client'];
 
     if (!$result) {
         http_response_code(401);
-        log_message("ERROR", "Invalid API Key: $api_key", $client, $hostname, $client_ip, $conn);
+        log_message("ERROR", "Invalid API Key: $api_key", 'unknown', $hostname, $client_ip, $conn);
         exit;
     }
+
+    $server_name = $result['server_name'];
+    $client = $result['client'];
 
     // JSON 데이터에서 컬럼과 값을 동적으로 생성
     $columns = implode(", ", array_keys($data));


### PR DESCRIPTION
## Summary
- check API key query result before accessing fields
- log unauthorized API key attempts

## Testing
- `php -l report/api.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68673d46a0d88321a9b41a40990a849c