### PR TITLE
Add basic Spring Boot service

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@
    git clone https://github.com/minnewater/uzart.git
    ```
 2. (추가 설치 방법 및 환경 설정은 추후 업데이트 예정)
+3. Java 서버 빌드 및 실행
+   ```sh
+   cd java
+   mvn spring-boot:run
+   # 또는
+   mvn package
+   java -jar target/uzart-0.0.1-SNAPSHOT.jar
+   ```
 
 ---
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -1,0 +1,47 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>uzart</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>uzart</name>
+    <description>Uzart migration project</description>
+    <properties>
+        <java.version>17</java.version>
+        <spring-boot.version>3.1.2</spring-boot.version>
+    </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/java/src/main/java/com/example/uzart/UzartApplication.java
+++ b/java/src/main/java/com/example/uzart/UzartApplication.java
@@ -1,0 +1,12 @@
+package com.example.uzart;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class UzartApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(UzartApplication.class, args);
+    }
+}

--- a/java/src/main/java/com/example/uzart/controller/DataController.java
+++ b/java/src/main/java/com/example/uzart/controller/DataController.java
@@ -1,0 +1,21 @@
+package com.example.uzart.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class DataController {
+
+    /**
+     * Ingest raw data from clients.
+     * This mirrors the legacy PHP /api endpoint.
+     */
+    @PostMapping
+    public String ingest(@RequestBody String payload) {
+        // TODO: persist payload to database
+        return "Received: " + payload;
+    }
+}

--- a/java/src/main/resources/application.properties
+++ b/java/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:postgresql://${UZART_DB_HOST:localhost}:${UZART_DB_PORT:5432}/${UZART_DB_NAME:uzart}
+spring.datasource.username=${UZART_DB_USER:}
+spring.datasource.password=${UZART_DB_PASS:}
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.jpa.hibernate.ddl-auto=none


### PR DESCRIPTION
## Summary
- set up a new `java` Maven project for Spring Boot
- add a `/api` controller for data ingestion
- configure PostgreSQL connection through `application.properties`
- document how to build and run the new service

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68674e9ee9f48321bd26eb240dfe1e65