### PR TITLE
Add environment template and update setup docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Uzart environment variables
+# Copy this file to .env and customize the values as needed
+
+# PostgreSQL connection settings
+UZART_DB_HOST=localhost
+UZART_DB_PORT=5432
+UZART_DB_NAME=uzart
+UZART_DB_USER=uzart
+UZART_DB_PASS=change_me
+# SSL mode for PostgreSQL (disable, prefer, require, verify-ca, verify-full)
+UZART_DB_SSLMODE=prefer

--- a/README.md
+++ b/README.md
@@ -24,7 +24,12 @@
    ```sh
    git clone https://github.com/minnewater/uzart.git
    ```
-2. (추가 설치 방법 및 환경 설정은 추후 업데이트 예정)
+2. 환경 변수 설정
+   `.env.example` 파일을 복사하여 `.env`로 만든 뒤 DB 접속 정보를 입력합니다.
+   ```sh
+   cp .env.example .env
+   # 에디터로 .env 파일을 열어 UZART_DB_* 값을 수정
+   ```
 3. Java 서버 빌드 및 실행
    ```sh
    cd java


### PR DESCRIPTION
## Summary
- provide a `.env.example` template for database variables
- update README setup section to explain how to use this file

## Testing
- `mvn -f java/pom.xml -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867559936a8832193ab7fb55ceea493