### PR TITLE
Fix PDF font paths

### DIFF
--- a/report/uzart/www/api/check_report.php
+++ b/report/uzart/www/api/check_report.php
@@ -97,8 +97,8 @@ $pdf->SetMargins(10, 10, 10);
 $pdf->SetAutoPageBreak(true, 10);
 
 // 폰트 설정 (NanumGothic 폰트를 사전에 등록해두었음)
-$pdf->AddFont('NanumGothic','','Nanum/NanumGothic.ttf',true);
-$pdf->AddFont('NanumGothic','B','Nanum/NanumGothicBold.ttf',true);
+$pdf->AddFont('NanumGothic','', 'unifont/Nanum/NanumGothic.ttf', true);
+$pdf->AddFont('NanumGothic','B', 'unifont/Nanum/NanumGothicBold.ttf', true);
 
 //$pdf->SetCreator(PDF_CREATOR);
 $pdf->SetAuthor('Linux Server Audit');

--- a/report/uzart/www/api/view_report.php
+++ b/report/uzart/www/api/view_report.php
@@ -100,8 +100,8 @@ $pdf->SetAutoPageBreak(true, 10);
 $pdf->AddPage();
 
 // 폰트 설정 (NanumGothic 폰트를 사전에 등록해두었음)
-$pdf->AddFont('NanumGothic','','Nanum/NanumGothic.ttf',true);
-$pdf->AddFont('NanumGothic','B','Nanum/NanumGothicBold.ttf',true);
+$pdf->AddFont('NanumGothic','', 'unifont/Nanum/NanumGothic.ttf', true);
+$pdf->AddFont('NanumGothic','B', 'unifont/Nanum/NanumGothicBold.ttf', true);
 
 // 표지 페이지
 $pdf->Image($logoPath, $pdf->GetPageWidth() - 40, 30, 30);


### PR DESCRIPTION
## Summary
- ensure the NanumGothic fonts load correctly by referencing the `unifont` directory

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68675c889b9c8321bdabe5e20726e674