### PR TITLE
Fix DB connection and report status check

### DIFF
--- a/report/api.php
+++ b/report/api.php
@@ -93,7 +93,11 @@ if ($request_method === 'POST') {
 
     try {
         // 데이터베이스 연결
-	$conn = new PDO("pgsql:host=" . DB_HOST . ";dbname=" . DB_NAME, DB_USER, DB_PASS);
+        $conn = new PDO(
+            "pgsql:host=" . $DB_HOST . ";dbname=" . $DB_NAME,
+            $DB_USER,
+            $DB_PASS
+        );
         //$conn = new PDO("pgsql:host=$DB_HOST;dbname=$DB_NAME", $DB_USER, $DB_PASS);
         $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
     } catch (PDOException $e) {

--- a/report/uzart/www/api/view_report.php
+++ b/report/uzart/www/api/view_report.php
@@ -40,8 +40,14 @@ $checkStatuses = $checkStmt->fetchAll(PDO::FETCH_KEY_PAIR);
 //error_log("Check statuses: " . print_r($checkStatuses, true));
 
 foreach ($idArr as $id) {
-    if (!isset($checkStatuses[$id]) || $checkStatuses[$id] !== true) {
-        echo json_encode(['success' => false, 'message' => "ID $id 보고서는 점검필요 상태로 조회할 수 없습니다."]);
+    // PostgreSQL boolean은 't' 또는 'f' 문자열로 반환될 수 있으므로
+    $status = $checkStatuses[$id] ?? null;
+    $statusBool = filter_var($status, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+    if ($statusBool !== true) {
+        echo json_encode([
+            'success' => false,
+            'message' => "ID $id 보고서는 점검필요 상태로 조회할 수 없습니다."
+        ]);
         exit();
     }
 }


### PR DESCRIPTION
## Summary
- fix usage of DB credentials when receiving JSON API data
- ensure view_report correctly handles boolean values from PostgreSQL

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*
- `php -v` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68677792a14083219e14740b5b40b485