### PR TITLE
Fix invalid PDF output

### DIFF
--- a/report/uzart/www/api/view_report.php
+++ b/report/uzart/www/api/view_report.php
@@ -279,6 +279,9 @@ error_log("Converted clientName: " . $clientName);
 error_log("fileName: " . $fileName);
 
 if ($_GET['download'] == '1') {
+    if (ob_get_length()) {
+        ob_clean();
+    }
     header('Content-Type: application/pdf');
     header("Content-Disposition: attachment; filename=\"$fileName\"");
     $pdf->Output("D", $fileName);
@@ -290,6 +293,9 @@ if ($_GET['download'] == '1') {
         header('HTTP/1.1 500 Internal Server Error');
         echo json_encode(['success' => false, 'message' => 'PDF 생성 실패']);
         exit();
+    }
+    if (ob_get_length()) {
+        ob_clean();
     }
     header('Content-Type: application/pdf');
     header("Content-Disposition: attachment; filename=\"$fileName\"");


### PR DESCRIPTION
## Summary
- clear any output before sending PDF files to avoid corruption

## Testing
- `php -l report/uzart/www/api/view_report.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b39e4fd48832198091f6adaeadeb6